### PR TITLE
dictgen için yerel dizin kontrolü

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pip install pyglossary
 pip install spylls
 ```
 # Kobo sözlüğünü yükleme
-* Sözlüğü doğrudan `KOBOeReader/.kobo/custom-dict` konumuna kopyalayın.
+* Sözlüğü (zip dosyasını) doğrudan `KOBOeReader/.kobo/custom-dict` konumuna kopyalayın.
 * Kaynak ve detaylı açıklama için [buraya](https://pgaskin.net/dictutil/dicthtml/install.html) başvurun.
 
 <details>

--- a/src/gts.py
+++ b/src/gts.py
@@ -3,6 +3,7 @@ import gzip
 import html
 import json
 import platform
+import os
 import re
 import subprocess
 import tarfile
@@ -21,6 +22,15 @@ from spylls.hunspell.dictionary import Dictionary
 
 SURUM = (2, 4, 3)
 BETIK_DY = Path(__file__).resolve().parent
+
+def which_ex(cmd: str) -> str:
+    path = os.environ.get("PATH", os.defpath)
+    cwd = Path.cwd()
+    arama_dizini = f"{path}{os.pathsep}{cwd}"
+    sonuc = which(cmd=cmd, path=arama_dizini)
+    if not sonuc: 
+        return sonuc
+    return str(Path(sonuc).resolve())
 
 def html_escape(metin: str) -> str:
     return html.escape(metin)
@@ -610,22 +620,14 @@ class GTS:
                 df_satirlar_yeni.append(satir)
         dosya_ismi.write_text("\n".join(df_satirlar_yeni), encoding="utf-8")
 
-        bin_name = self.platform_uygun_dictgen_ismi
-        local_bin_path = BETIK_DY / bin_name
-        executable_cmd = None
-        if local_bin_path.exists():
-            local_bin_path.chmod(0o755)
-            executable_cmd = str(local_bin_path)
-        elif which(bin_name):
-            executable_cmd = bin_name
-
-        if not executable_cmd:
+        dictgen_yolu = which_ex(self.platform_uygun_dictgen_ismi)
+        if not dictgen_yolu:
             raise Exception(
                 "[!] Kobo biçim dönüşümünü yapacak çalıştırılabilir dosya PATH'de ve betiğin olduğu klasörde bulunamadı. " \
                 "Dosyanın PATH'de veya betiğin çalıştığı klasörde bulunabilir olduğundan emin olun. " \
                 "Dosyaları edinmek için https://github.com/pgaskin/dictutil/releases adresine başvurun.")
         
-        subprocess.Popen([executable_cmd, str(dosya_ismi),
+        subprocess.Popen([dictgen_yolu, str(dosya_ismi),
                           "-o", str(klasor / "dicthtml-tr.zip")],
                           stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 

--- a/src/gts.py
+++ b/src/gts.py
@@ -446,7 +446,7 @@ class GTS:
             if platform.machine().startswith("arm") or platform.machine().startswith("aarch"):
                 return "dictgen-linux-arm"
             if platform.machine() in ["x86_64", "AMD64"]:
-                return "dictgen-linux-64bit"
+                return "dictgen-linux-64bit" # BURAYA GELIYOR
             # Belki 32bit kontrolü de yapabiliriz.
             raise Exception("[!] Sistem beklenmeyen bir mimari üzerinde çalışıyor.")
         raise Exception("[!] Betik bilinmeyen bir işletim sistemi üzerinde çalıştırılıyor.")
@@ -609,12 +609,23 @@ class GTS:
             else:
                 df_satirlar_yeni.append(satir)
         dosya_ismi.write_text("\n".join(df_satirlar_yeni), encoding="utf-8")
-        if not which(self.platform_uygun_dictgen_ismi):
+
+        bin_name = self.platform_uygun_dictgen_ismi
+        local_bin_path = BETIK_DY / bin_name
+        executable_cmd = None
+        if local_bin_path.exists():
+            local_bin_path.chmod(0o755)
+            executable_cmd = str(local_bin_path)
+        elif which(bin_name):
+            executable_cmd = bin_name
+
+        if not executable_cmd:
             raise Exception(
                 "[!] Kobo biçim dönüşümünü yapacak çalıştırılabilir dosya PATH'de bulunamadı. " \
                 "Dosyanın PATH'de bulunabilir olduğundan emin olun. " \
                 "Dosyaları edinmek için https://github.com/pgaskin/dictutil/releases adresine başvurun.")
-        subprocess.Popen([self.platform_uygun_dictgen_ismi, str(dosya_ismi),
+        
+        subprocess.Popen([executable_cmd, str(dosya_ismi),
                           "-o", str(klasor / "dicthtml-tr.zip")],
                           stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
 

--- a/src/gts.py
+++ b/src/gts.py
@@ -621,8 +621,8 @@ class GTS:
 
         if not executable_cmd:
             raise Exception(
-                "[!] Kobo biçim dönüşümünü yapacak çalıştırılabilir dosya PATH'de bulunamadı. " \
-                "Dosyanın PATH'de bulunabilir olduğundan emin olun. " \
+                "[!] Kobo biçim dönüşümünü yapacak çalıştırılabilir dosya PATH'de ve betiğin olduğu klasörde bulunamadı. " \
+                "Dosyanın PATH'de veya betiğin çalıştığı klasörde bulunabilir olduğundan emin olun. " \
                 "Dosyaları edinmek için https://github.com/pgaskin/dictutil/releases adresine başvurun.")
         
         subprocess.Popen([executable_cmd, str(dosya_ismi),

--- a/src/gts.py
+++ b/src/gts.py
@@ -637,7 +637,8 @@ class GTS:
         dosya_ismi = klasor / self.cikti_klasoru_ismi
         if not klasor.exists():
             klasor.mkdir()
-        glossary.write(filename=str(dosya_ismi), formatName="Mobi", kindlegen_path="kindlegen")
+        kindlegen_yolu = which_ex("kindlegen")
+        glossary.write(filename=str(dosya_ismi), formatName="Mobi", kindlegen_path=kindlegen_yolu)
         mobi_dosya_yolu = dosya_ismi / "OEBPS" / "content.mobi"
         if mobi_dosya_yolu.exists():
             mobi_dosya_yolu.replace(klasor / f"{self.cikti_klasoru_ismi}.mobi")

--- a/src/gts.py
+++ b/src/gts.py
@@ -446,7 +446,7 @@ class GTS:
             if platform.machine().startswith("arm") or platform.machine().startswith("aarch"):
                 return "dictgen-linux-arm"
             if platform.machine() in ["x86_64", "AMD64"]:
-                return "dictgen-linux-64bit" # BURAYA GELIYOR
+                return "dictgen-linux-64bit"
             # Belki 32bit kontrolü de yapabiliriz.
             raise Exception("[!] Sistem beklenmeyen bir mimari üzerinde çalışıyor.")
         raise Exception("[!] Betik bilinmeyen bir işletim sistemi üzerinde çalıştırılıyor.")

--- a/src/gts.py
+++ b/src/gts.py
@@ -28,7 +28,7 @@ def which_ex(cmd: str) -> str:
     cwd = Path.cwd()
     arama_dizini = f"{path}{os.pathsep}{cwd}"
     sonuc = which(cmd=cmd, path=arama_dizini)
-    if not sonuc: 
+    if not sonuc:
         return sonuc
     return str(Path(sonuc).resolve())
 
@@ -626,7 +626,7 @@ class GTS:
                 "[!] Kobo biçim dönüşümünü yapacak çalıştırılabilir dosya PATH'de ve betiğin olduğu klasörde bulunamadı. " \
                 "Dosyanın PATH'de veya betiğin çalıştığı klasörde bulunabilir olduğundan emin olun. " \
                 "Dosyaları edinmek için https://github.com/pgaskin/dictutil/releases adresine başvurun.")
-        
+
         subprocess.Popen([dictgen_yolu, str(dosya_ismi),
                           "-o", str(klasor / "dicthtml-tr.zip")],
                           stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
@@ -638,6 +638,11 @@ class GTS:
         if not klasor.exists():
             klasor.mkdir()
         kindlegen_yolu = which_ex("kindlegen")
+        if not kindlegen_yolu:
+            raise Exception(
+                "[!] Kindle MOBI dönüşümünü yapacak çalıştırılabilir dosya (kindlegen) PATH'de ve betiğin olduğu klasörde bulunamadı. " \
+                "Dosyanın PATH'de veya betiğin çalıştığı klasörde bulunabilir olduğundan emin olun. " \
+                "Dosyaları edinmek için https://web.archive.org/web/20190817070956/https://www.amazon.com/gp/feature.html?docId=1000765211 adresine başvurun.")
         glossary.write(filename=str(dosya_ismi), formatName="Mobi", kindlegen_path=kindlegen_yolu)
         mobi_dosya_yolu = dosya_ismi / "OEBPS" / "content.mobi"
         if mobi_dosya_yolu.exists():


### PR DESCRIPTION
Güzel yazılımın için teşekkürler. Kobo'ma kurdum ve kullanıyorum, eline sağlık.

dictgen kütüphanesi bende kurulu olmadığı için exception'a düştüm. dictgen betiğini exception'da çıkan mesajdaki linkten indirip direkt src klasörünün içine atmak bana daha pratik geldi. Ayrıca kütüphanenin sistem geneli kurulumu hata verdi, yani tek şansım direkt dictgen betiğini kullanmaktı. (arch linux kullanıyorum bu arada)

Kendi kullanımım için yaptığım yamayı paylaşıyorum. Ayrıca README'yi biraz daha kullanıcı dostu hale getirmeni içtenlikle rica ediyorum. Bu halini anlamak genel okuyucu kitlesi için biraz zor olabilir.

Saygılarımla